### PR TITLE
Removed name from RDS instance definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,8 +46,6 @@ resource "aws_db_parameter_group" "this" {
 }
 
 resource "aws_db_instance" "this" {
-  name = var.name
-
   allocated_storage                   = var.storage
   backup_retention_period             = var.backup_retention_period
   copy_tags_to_snapshot               = var.copy_tags_to_snapshot


### PR DESCRIPTION
Name in RDS is only used for the initial database creation. We don't care about it and this var is used elsewhere. MySQL only allows alphanumeric characters for the database name which hurts us for everything else. No need to set this so this is the easiest solution.