### PR TITLE
id -> identifier

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -15,8 +15,8 @@ output "instance_connection_info" {
 }
 
 output "instance_id" {
-  description = "Instance ID of RDS DB"
-  value       = aws_db_instance.this.id
+  description = "Instance `identifier` NOT `id` of RDS DB. For backwards compatibility. See [change](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#aws_db_instanceid-is-no-longer-the-identifier)"
+  value       = aws_db_instance.this.identifier
 }
 output "password_secret_arn" {
   description = "Password secret ARN"


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#aws_db_instanceid-is-no-longer-the-identifier