### PR TITLE
Make trivy ignore misconfiguration in examples

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,4 +1,4 @@
-
+#trivy:ignore:AVD-AWS-0176
 module "basic" {
   source = "../.."
 

--- a/examples/parameters/main.tf
+++ b/examples/parameters/main.tf
@@ -1,4 +1,4 @@
-
+#trivy:ignore:AVD-AWS-0176
 module "basic" {
   source = "../.."
 


### PR DESCRIPTION
Examples in this module were preventing successful trivy configuration checks in other projects that use this module. This fix only suppresses these misconfiguration warnings as they pertain to the examples. This does not prevent trivy from alerting on this issue within another TF project.

[https://avd.aquasec.com/misconfig/avd-aws-0176](https://avd.aquasec.com/misconfig/avd-aws-0176)